### PR TITLE
Use uppercase HEAD in git script

### DIFF
--- a/bin/git-up
+++ b/bin/git-up
@@ -20,7 +20,7 @@ pull_args = ARGV.to_a
 
 rebase = File.basename($0) == 'git-reup'
 
-old_head = `git rev-parse head`.chomp
+old_head = `git rev-parse HEAD`.chomp
 
 exit($?.to_i) unless $? == 0
 
@@ -31,7 +31,7 @@ end
 
 system "git pull #{pull_args.shelljoin}"
 
-updated = (old_head != `git rev-parse head`.chomp)
+updated = (old_head != `git rev-parse HEAD`.chomp)
 
 if updated
   if rebase


### PR DESCRIPTION
The HEAD keyword seems to be case sensitive on Linux.

Using the lower case causes the following error:
fatal: ambiguous argument 'head': unknown revision or path not in the working tree.

See also: https://stackoverflow.com/questions/25976794/is-head-in-git-case-insensitive-on-all-platforms